### PR TITLE
Remove Belorussian translation

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,3 @@ These are the resources I found most useful while implementing the line breaking
 * [Breaking paragraphs into lines, Donald E. Knuth, Michael F. Plass](http://www3.interscience.wiley.com/journal/113445055/abstract)
 * [Knuth & Plass line-breaking Revisited](http://defoe.sourceforge.net/folio/knuth-plass.html)
 * [Wikipedia: Word wrap](http://en.wikipedia.org/w/index.php?title=Word_wrap)
-
-### Translations
-
-* [Belorussian translation](http://webhostingrating.com/libs/typeset-be)

--- a/examples/article/index.html
+++ b/examples/article/index.html
@@ -104,11 +104,6 @@
 			<li><a href="http://en.wikipedia.org/w/index.php?title=Word_wrap">Wikipedia: Word wrap</a></li>
 		</ul>
 
-        <h2>Translations</h2>
-        <ul>
-            <li><a href="http://webhostingrating.com/libs/typeset-be">Belorussian translation</a></li>
-        </ul>
-
 		<span style="font-family: sans-serif; font-size: 12px;" id="test">&nbsp;</span>
 
 		<script type="text/javascript" src="../../lib/jquery-1.4.2.js"></script>


### PR DESCRIPTION
The Belorussian translation page has a broken link, so remove.

Also, be careful with accepting other people's translations. I've found that they are often machine-generated to pass pagerank from popular pages (such as yours) to theirs. When in doubt, check the domain name: if it seems unrelated (like the `webhostingrating.com` in your case), it is probably spammy.