### PR TITLE
Support Hi-DPI screens better in the examples

### DIFF
--- a/examples/article/index.html
+++ b/examples/article/index.html
@@ -164,8 +164,15 @@
 				function align(identifier, type, lineLengths, tolerance, center) {
 					var canvas = $(identifier).get(0),
                     context = canvas.getContext && canvas.getContext('2d'),
+                    devicePixelRatio = window.devicePixelRatio || 1,
                     format, nodes, breaks;
 					if (context) {
+						canvas.style.width = canvas.width + 'px';
+						canvas.style.height = canvas.height + 'px';
+						canvas.width *= devicePixelRatio;
+						canvas.height *= devicePixelRatio;
+						context.scale(devicePixelRatio, devicePixelRatio);
+
 						context.textBaseline = 'top';
 						context.font = "14px 'times new roman', 'FreeSerif', serif";
 


### PR DESCRIPTION
Text respects the device pixel ratio, but canvas doesn’t automatically; adjusting its scaling makes it render in terms of device pixels rather than CSS screen pixels. Thus we get non-fuzzy text in the canvas.
